### PR TITLE
Don't use time for checking WAR in retire stage

### DIFF
--- a/src/simulator/Op_fetch.hpp
+++ b/src/simulator/Op_fetch.hpp
@@ -25,6 +25,7 @@ bool Op_fetch::read_operands(int fu_index)
 	if (!fue.rj || !fue.rk || !fue.rl)
 		return false;
 
+	// TODO: is it necessary
 	if (fue.fetched)
 		return false; /* Operand already fetched */
 
@@ -35,6 +36,10 @@ bool Op_fetch::read_operands(int fu_index)
 		fue.fk = RegSet::gpr[fue.fk];
 	if (fue.fl != -1)
 		fue.fl = RegSet::gpr[fue.fl];
+
+	fue.rj = false;
+	fue.rk = false;
+	fue.rl = false;
 
 	/* set fetched state to true */
 	fue.fetched = true;

--- a/src/simulator/Retire.hpp
+++ b/src/simulator/Retire.hpp
@@ -54,26 +54,20 @@ bool Retire::check_war(fu_enum fu)
 
 		auto &fue_f = fu_status[f];
 
-		/*
-		 * The current instruction to be retired should have higher time
-		 * at which it was issud than an instruction for WAR to be possible.
-		 * Since only busy status of functional unit is reset in our code after
-		 * retiring, so the FU must be busy for WAR to be possible.
-		 */
-		if (fue.time < fue_f.time || !fue_f.busy)
-			continue;
-
 		int fj_f = fue_f.fj;
 		int fk_f = fue_f.fk;
 		int fl_f = fue_f.fl;
 		bool fetched_f = fue_f.fetched;
+		bool rj_f = fue_f.rj;
+		bool rk_f = fue_f.rk;
+		bool rl_f = fue_f.rl;
 
 		/* current fu has to write to some reg */
 		bool is_write = fi != -1;
 		/* dest reg of current fu matches to src reg of some fu */
-		bool war = (fj_f == fi) || (fk_f == fi) || (fl_f == fi);
+		bool war = ((fj_f != fi) || (!rj_f)) && ((fk_f != fi) || (!rk_f)) && ((fl_f != fi) || (!rl_f));
 
-		if (is_write && war && !fetched_f)
+		if (is_write && !war && !fetched_f)
 			return true;
 	}
 	return false;


### PR DESCRIPTION
In actual scoreboarding implementation acording to wikipedia time is not
checked for checking WAR.

fix #8